### PR TITLE
Update jQuery to v3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "semver": "^2.2.1"
   },
   "dependencies": {
-    "jquery": "3.4.1"
+    "jquery": "^3.5.0"
   }
 }


### PR DESCRIPTION
Hello, I found your version of `bootstrap-tokenfield` on npm and it'd be time to update again the jQuery version to at least 3.5.0 to get some security fixes: https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/

Could you check this PR and publish a new version of `bootstrap-tokenfield-jquery3` on npm? That'd be great! 👍 